### PR TITLE
added missing #include

### DIFF
--- a/src/list_graph.h
+++ b/src/list_graph.h
@@ -5,6 +5,8 @@
 
 #include <tuple>
 
+#include <string>
+
 struct ListGraph{
 	ListGraph()=default;
 	ListGraph(int node_count, int arc_count)


### PR DESCRIPTION
This is causing a compile error with newer versions of gcc. The context for this patch is [this pull request to Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/pull/10221).